### PR TITLE
Don't use FindAttachments

### DIFF
--- a/html/Ticket/AttachmentZip/dhandler
+++ b/html/Ticket/AttachmentZip/dhandler
@@ -6,7 +6,7 @@ my ($mode,$ticket_no) = ($m->dhandler_arg =~ m/^((?:all|current))\/(\d+)\//i );
 my $Ticket = LoadTicket($ticket_no);
 
 # collect individual attached files in a hash of arrays
-my $AttachObj = $m->comp('/Ticket/Elements/FindAttachments', Ticket => $Ticket);
+my $AttachObj = $Ticket->Attachments;
 my %attached_files;
 while (my $attached_name = $AttachObj->Next() ) {
   next unless ($attached_name->Filename());

--- a/html/Ticket/Elements/ShowAttachments
+++ b/html/Ticket/Elements/ShowAttachments
@@ -102,7 +102,7 @@ if ($size) {
 
 # If we haven't been passed in an Attachments object (through the precaching mechanism)
 # then we need to find one
-$Attachments ||= $m->comp('FindAttachments', Ticket => $Ticket);
+$Attachments ||= $Ticket->Attachments;
 
 my %documents;
 while ( my $attach = $Attachments->Next() ) {


### PR DESCRIPTION
Doesn't work on RT 4.2 or newer, because this component was removed (https://github.com/bestpractical/rt/commit/a52805c7e8fdf48cda95da92c6d655b39cbe3615)

This allows it to work again (and it works great!)